### PR TITLE
Connect OTel-Demo to TallyCat

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ OTEL_JAVA_AGENT_VERSION=2.20.1
 OPENTELEMETRY_CPP_VERSION=1.21.0
 
 # Dependent images
-COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.133.0
+COLLECTOR_CONTRIB_IMAGE=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.136.0
 FLAGD_IMAGE=ghcr.io/open-feature/flagd:v0.12.8
 GRAFANA_IMAGE=grafana/grafana:12.1.0
 JAEGERTRACING_IMAGE=jaegertracing/jaeger:2.10.0
@@ -76,13 +76,13 @@ EMAIL_DOCKERFILE=./src/email/Dockerfile
 FRAUD_DOCKERFILE=./src/fraud-detection/Dockerfile
 
 # Frontend
-FRONTEND_PORT=8080
+FRONTEND_PORT=8085
 FRONTEND_ADDR=frontend:${FRONTEND_PORT}
 FRONTEND_DOCKERFILE=./src/frontend/Dockerfile
 
 # Frontend Proxy (Envoy)
 FRONTEND_HOST=frontend
-ENVOY_PORT=8080
+ENVOY_PORT=8085
 ENVOY_ADMIN_PORT=10000
 FRONTEND_PROXY_ADDR=frontend-proxy:${ENVOY_PORT}
 FRONTEND_PROXY_DOCKERFILE=./src/frontend-proxy/Dockerfile

--- a/docker-compose-hack.yml
+++ b/docker-compose-hack.yml
@@ -571,6 +571,7 @@ services:
       - "tempo.k3d.localhost:host-gateway"
       - "mimir.k3d.localhost:host-gateway"
       - "loki.k3d.localhost:host-gateway"
+      - "tallycat.k3d.localhost:host-gateway"
     logging: *logging
     environment:
       - ENVOY_PORT

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -148,7 +148,7 @@ data:
         - datasourceUid: webstore-traces
           name: trace_id
         - name: trace_id
-          url: http://localhost:8080/jaeger/ui/trace/$${__value.raw}
+          url: http://localhost:8085/jaeger/ui/trace/$${__value.raw}
           urlDisplayLabel: View in Jaeger UI
       name: Prometheus
       type: prometheus
@@ -328,7 +328,7 @@ data:
     receivers:
       httpcheck/frontend-proxy:
         targets:
-        - endpoint: http://frontend-proxy:8080
+        - endpoint: http://frontend-proxy:8085
       jaeger:
         protocols:
           grpc:

--- a/src/otel-collector/otelcol-config-hack.yml
+++ b/src/otel-collector/otelcol-config-hack.yml
@@ -95,17 +95,23 @@ exporters:
   debug:
   # OTLP gRPC exporter for traces to Tempo
   otlp/tempo:
-    endpoint: "tempo.k3d.localhost:9999"
+    endpoint: "tempo.k3d.localhost:4317"
     tls:
       insecure: true
   # OTLP HTTP exporter for metrics to Mimir
   otlphttp/mimir:
-    endpoint: "http://mimir.k3d.localhost:9999/otlp" 
+    endpoint: "http://mimir.k3d.localhost:9009/otlp" 
     tls:
       insecure: true
   # OTLP HTTP exporter for logs to Loki
   otlphttp/loki:
-    endpoint: "http://loki.k3d.localhost:9999/otlp"
+    endpoint: "http://loki.k3d.localhost:3100/otlp"
+
+  otlp/tallycat:
+    endpoint: "tallycat.k3d.localhost:4317"
+    tls:
+      insecure: true
+    compression: none
 
 processors:
   batch:
@@ -131,15 +137,15 @@ service:
     traces:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, transform, batch]
-      exporters: [otlp/tempo, debug, spanmetrics]
+      exporters: [otlp/tempo, debug, spanmetrics, otlp/tallycat]
     metrics:
       receivers: [docker_stats, httpcheck/frontend-proxy, hostmetrics, nginx, otlp, spanmetrics]
       processors: [resourcedetection, memory_limiter, batch]
-      exporters: [otlphttp/mimir, debug]
+      exporters: [otlphttp/mimir, debug, otlp/tallycat]
     logs:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, batch]
-      exporters: [otlphttp/loki]
+      exporters: [otlphttp/loki, otlp/tallycat]
   telemetry:
     metrics:
       level: detailed


### PR DESCRIPTION
Updates the demo environment to send OTLP data to TallyCat, in addition to the backends.

It also changes the port used by the demo front-end, so it doesn't conflict with TallyCat's