### PR TITLE
Fix telemetry to hack k3d cluster

### DIFF
--- a/docker-compose-hack.yml
+++ b/docker-compose-hack.yml
@@ -568,10 +568,8 @@ services:
       - "${OTEL_COLLECTOR_PORT_GRPC}"
       - "${OTEL_COLLECTOR_PORT_HTTP}"
     extra_hosts:
-      - "tempo.k3d.localhost:host-gateway"
       - "mimir.k3d.localhost:host-gateway"
       - "loki.k3d.localhost:host-gateway"
-      - "tallycat.k3d.localhost:host-gateway"
     logging: *logging
     environment:
       - ENVOY_PORT
@@ -597,7 +595,6 @@ services:
       - /proc:/proc:ro
     environment:
       - BEYLA_CONFIG_FILE=/etc/beyla/beyla-config.yml
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_GRPC}
     depends_on:
       otel-collector:
         condition: service_started

--- a/src/otel-collector/otelcol-config-hack.yml
+++ b/src/otel-collector/otelcol-config-hack.yml
@@ -95,20 +95,20 @@ exporters:
   debug:
   # OTLP gRPC exporter for traces to Tempo
   otlp/tempo:
-    endpoint: "tempo.k3d.localhost:4317"
+    endpoint: "host.docker.internal:31317"
     tls:
       insecure: true
   # OTLP HTTP exporter for metrics to Mimir
   otlphttp/mimir:
-    endpoint: "http://mimir.k3d.localhost:9009/otlp" 
+    endpoint: "http://mimir.k3d.localhost:9999/otlp" 
     tls:
       insecure: true
   # OTLP HTTP exporter for logs to Loki
   otlphttp/loki:
-    endpoint: "http://loki.k3d.localhost:3100/otlp"
+    endpoint: "http://loki.k3d.localhost:9999/otlp"
 
   otlp/tallycat:
-    endpoint: "tallycat.k3d.localhost:4317"
+    endpoint: "host.docker.internal:30417"
     tls:
       insecure: true
     compression: none
@@ -137,11 +137,11 @@ service:
     traces:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, transform, batch]
-      exporters: [otlp/tempo, debug, spanmetrics, otlp/tallycat]
+      exporters: [otlp/tempo, spanmetrics, otlp/tallycat]
     metrics:
       receivers: [docker_stats, httpcheck/frontend-proxy, hostmetrics, nginx, otlp, spanmetrics]
       processors: [resourcedetection, memory_limiter, batch]
-      exporters: [otlphttp/mimir, debug, otlp/tallycat]
+      exporters: [otlphttp/mimir, otlp/tallycat]
     logs:
       receivers: [otlp]
       processors: [resourcedetection, memory_limiter, batch]


### PR DESCRIPTION
Tempo and Tallycat send OTel data via grpc which had to be changed.
